### PR TITLE
chore: Migrate gsutil usage to gcloud storage

### DIFF
--- a/repositories/http_archive_deps/README.md
+++ b/repositories/http_archive_deps/README.md
@@ -23,7 +23,7 @@ Example output:
 
 ```
 # ⚠️  bazelbuild-bazel-skylib-1.0.3.tar.gz is not uploaded yet. Upload with:
-gsutil cp -n -a public-read /usr/local/google/home/aaronyu/.cache/bazel/_bazel_aaronyu/cache/repos/v1/content_addressable/sha256/1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c/file gs://chromeos-localmirror/distfiles/bazelbuild-bazel-skylib-1.0.3.tar.gz
+gcloud storage cp --no-clobber --predefined-acl=public-read /usr/local/google/home/aaronyu/.cache/bazel/_bazel_aaronyu/cache/repos/v1/content_addressable/sha256/1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c/file gs://chromeos-localmirror/distfiles/bazelbuild-bazel-skylib-1.0.3.tar.gz
 # ✅  google-benchmark-v1.5.5.tar.gz already exist at: https://storage.googleapis.com/chromeos-localmirror/distfiles/google-benchmark-v1.5.5.tar.gz
 ```
 

--- a/repositories/http_archive_deps/README.md
+++ b/repositories/http_archive_deps/README.md
@@ -23,7 +23,7 @@ Example output:
 
 ```
 # ⚠️  bazelbuild-bazel-skylib-1.0.3.tar.gz is not uploaded yet. Upload with:
-gcloud storage cp --no-clobber --predefined-acl=public-read /usr/local/google/home/aaronyu/.cache/bazel/_bazel_aaronyu/cache/repos/v1/content_addressable/sha256/1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c/file gs://chromeos-localmirror/distfiles/bazelbuild-bazel-skylib-1.0.3.tar.gz
+gcloud storage cp --no-clobber --predefined-acl=publicRead /usr/local/google/home/aaronyu/.cache/bazel/_bazel_aaronyu/cache/repos/v1/content_addressable/sha256/1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c/file gs://chromeos-localmirror/distfiles/bazelbuild-bazel-skylib-1.0.3.tar.gz
 # ✅  google-benchmark-v1.5.5.tar.gz already exist at: https://storage.googleapis.com/chromeos-localmirror/distfiles/google-benchmark-v1.5.5.tar.gz
 ```
 

--- a/repositories/http_archive_deps/check_mirror.py
+++ b/repositories/http_archive_deps/check_mirror.py
@@ -77,11 +77,11 @@ def main(deps_sha256_json, json_bazel_external_uris_exclude):
                 print(
                     shlex.join(
                         [
-                            'gsutil',
+                            'gcloud',
+                            'storage',
                             'cp',
-                            '-n',
-                            '-a',
-                            'public-read',
+                            '--no-clobber',
+                            '--predefined-acl=public-read',
                             cached_download_file,
                             'gs://chromeos-localmirror/distfiles/' + canonical_name,
                         ]

--- a/repositories/http_archive_deps/check_mirror.py
+++ b/repositories/http_archive_deps/check_mirror.py
@@ -81,7 +81,7 @@ def main(deps_sha256_json, json_bazel_external_uris_exclude):
                             'storage',
                             'cp',
                             '--no-clobber',
-                            '--predefined-acl=public-read',
+                            '--predefined-acl=publicRead',
                             cached_download_file,
                             'gs://chromeos-localmirror/distfiles/' + canonical_name,
                         ]


### PR DESCRIPTION
Automated: Migrate {target_path} from gsutil to gcloud storage

This CL is part of the on going effort to migrate from the legacy `gsutil` tool to the new and improved `gcloud storage` command-line interface.
`gcloud storage` is the recommended and modern tool for interacting with Google Cloud Storage, offering better performance, unified authentication, and a more consistent command structure with other `gcloud` components. 🚀

### Automation Details

This change was **generated automatically** by an agent that targets users of `gsutil`.
The transformations applied are based on the  [gsutil to gcloud storage migration guide](http://go/gsutil-gcloud-storage-migration-guide).

### ⚠️ Action Required: Please Review and Test Carefully

While we have based the automation on the migration guide, every use case is unique.
**It is crucial that you thoroughly test these changes in environments appropriate to your use-case before merging.**  
Be aware of potential differences between `gsutil` and `gcloud storage` that could impact your workflows.  
For instance, the structure of command output may have changed, requiring updates to any scripts that parse it. Similarly, command behavior can differ subtly; the `gcloud storage rsync` command has a different file deletion logic than `gsutil rsync`, which could lead to unintended file deletions.  

Our migration guides can help guide you through a list of mappings and some notable differences between the two tools.

Standard presubmit tests are run as part of this CL's workflow. **If you need to target an additional test workflow or require assistance with testing, please let us know.**

Please verify that all your Cloud Storage operations continue to work as expected to avoid any potential disruptions in production.

### Support and Collaboration

The `GCS CLI` team is here to help! If you encounter any issues, have a complex use case that this automated change doesn't cover, or face any other blockers, please don't hesitate to reach out.
We are happy to work with you to test and adjust these changes as needed.

**Contact:** `gcs-cli-hyd@google.com`

We appreciate your partnership in this important migration effort!

#gsutil-migration
